### PR TITLE
Fix unrequested service start

### DIFF
--- a/mobile/src/main/java/rkr/weardndsync/BootReceiver.java
+++ b/mobile/src/main/java/rkr/weardndsync/BootReceiver.java
@@ -9,15 +9,14 @@ public class BootReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            intent = new Intent(context, SettingsService.class);
-            context.startService(intent);
-        } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (android.os.Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP_MR1 ||
+                android.os.Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP) {
             intent = new Intent(context, LGHackService.class);
             context.startService(intent);
-        } else {
-            intent = new Intent(context, SettingsService.class);
-            context.startService(intent);
+            return;
         }
+
+        intent = new Intent(context, SettingsService.class);
+        context.startService(intent);
     }
 }

--- a/mobile/src/main/java/rkr/weardndsync/LGHackService.java
+++ b/mobile/src/main/java/rkr/weardndsync/LGHackService.java
@@ -50,10 +50,14 @@ public class LGHackService extends NotificationListenerService {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "Service is started");
 
-        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+        // Do not continue running this service at all if we are not L or LMR1 as it
+        // can be invoked by the android system itself if notification access is enabled
+        // on any Android API version.
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ||
+                android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
+            stopSelf();
             return Service.START_NOT_STICKY;
-        if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1)
-            return Service.START_NOT_STICKY;
+        }
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_SET_STATE);

--- a/mobile/src/main/java/rkr/weardndsync/SettingsService.java
+++ b/mobile/src/main/java/rkr/weardndsync/SettingsService.java
@@ -155,7 +155,7 @@ public class SettingsService extends WearableListenerService {
             Intent intent = new Intent(LGHackService.ACTION_CONNECTED);
             sendBroadcast(intent);
         } else {
-            if (mGoogleApiClient.isConnected()) {
+            if (!mGoogleApiClient.isConnected()) {
                 mGoogleApiClient.connect();
             }
 


### PR DESCRIPTION
- Fixed an error where googleApiClient.isConnected() forceSync() call checked for true instead of false.
- Do not create a lingering notification listener service (LGHackService) if the platform isn't "L"or "L_MR1". LGHackService is invoked by the system itself if the notification access was manually toggled on phones with any API.
- Simplify some code branches.