### PR TITLE
Updated README with a troubleshooting step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Watch support:
 - `adb shell settings put secure enabled_notification_listeners com.google.android.wearable.app/com.google.android.clockwork.stream.NotificationCollectorService:rkr.weardndsync/rkr.weardndsync.NotificationService`
 - Start Phone app, make sure all checks pass
 - If checks don't pass:
+  - Try running `adb shell cmd notification allow_listener rkr.weardndsync/rkr.weardndsync.NotificationService` after reconnecting Watch to ADB
   - You made an error in your setup
   - Your device is not supported
   - Check the logs that can be extracted with `Send Logs` button


### PR DESCRIPTION
On the Galaxy Watch 4, running the watch ADB command seems to have no effect and the checks in the phone app still failed. However, running `adb shell cmd notification allow_listener rkr.weardndsync/rkr.weardndsync.NotificationService` worked like a charm. Added this as a troubleshooting step in the README.